### PR TITLE
修改了config.yaml中的一处错误

### DIFF
--- a/script/conf/config.yaml
+++ b/script/conf/config.yaml
@@ -22,7 +22,7 @@ log_config:
 tls_config:
   enable_tls: false                # enable tls
   server_cert_path: "/host/resources/cert/server.crt"   # path for the Server Certificate
-  server_cert_key_path: "/host/resources/cert/server.key"  # path for the Server Key
+  server_private_key_path: "/host/resources/cert/server.key"  # path for the Server Key
   client_ca_cert_path: "/host/resources/client_ca"   # directory for the Client CA Certificate
 
 storage_config:


### PR DESCRIPTION
在使用mysql进行持久化操作时发现以下问题：
<img width="534" alt="1726737716421_48CA9D9B-4679-4623-8B7E-4567D36CC161" src="https://github.com/user-attachments/assets/2f0f4973-e5ed-4150-91e4-be1f8cead0ac">
经过排查发现是config.yaml文件中tls配置中的server_cert_key_path应该修改为server_private_key_path
修改完成后再次执行 ./capsule_manager_grpc --config_path ./config.yaml成功。
![image](https://github.com/user-attachments/assets/d89641fe-ee70-44c7-aed8-ac28cd910def)
